### PR TITLE
fix: don't put erroneous ifds back on the stack

### DIFF
--- a/src/exif/exif_iter.rs
+++ b/src/exif/exif_iter.rs
@@ -414,7 +414,6 @@ impl Iterator for ExifIter {
                             tracing::warn!(?tag_code, ?e, "parse ifd entry error");
                             let res =
                                 Some(ParsedExifEntry::make_err(ifd.ifd_idx, tag_code.unwrap(), e));
-                            self.ifds.push(ifd);
                             return res;
                         }
                     }


### PR DESCRIPTION
This avoids an endless loop that happened with an actual image file.
I don't know much about EXIF, so I can't say whether this is the correct way of fixing the problem.
I also can't judge whether the exif data is actually valid in the file, but exiftool and different picture viewers can display the exif data.
Nevertheless, returning Errors from malformed files is ok, an endless loop is not ok.
I tried to attach an the file in question (resized to 1x1), hoping it survives being handled by github.
![broken-exif](https://github.com/user-attachments/assets/8e3067dc-a71a-4ed6-9dd2-3935bfc29567)


Review / Feedback is appreciated.