### PR TITLE
fix: explicit slice coercion in MotionPhoto attribute comparison

### DIFF
--- a/src/jpeg.rs
+++ b/src/jpeg.rs
@@ -134,8 +134,8 @@ fn container_motion_photo_offset(xmp: &[u8]) -> Option<u64> {
     }
 
     let mp_idx = items.iter().position(|tag| {
-        extract_attr_value(tag, b"Item:Semantic") == Some(b"MotionPhoto")
-            || extract_attr_value(tag, b"Item:Mime") == Some(b"video/mp4")
+        extract_attr_value(tag, b"Item:Semantic") == Some(&b"MotionPhoto"[..])
+            || extract_attr_value(tag, b"Item:Mime") == Some(&b"video/mp4"[..])
     })?;
 
     // Each item's `Item:Padding` is the gap between this item and the


### PR DESCRIPTION
## Problem

`cargo clippy`/`cargo build` fails in `src/jpeg.rs` when rkyv is present
elsewhere in the dependency graph:
```
error[E0277]: can't compare `Option<&[u8]>` with `Option<&[u8; 11]>`
error[E0277]: can't compare `Option<&[u8]>` with `Option<&[u8; 9]>`
```
`extract_attr_value()` returns `Option<&[u8]>`, while the literals `Some(b"MotionPhoto")` and `Some(b"video/mp4")` are `Option<&[u8; N]>`. The comparison normally works because Rust coerces
the array reference to a slice — but that coercion only fires when the target type is unambiguous.

rkyv's blanket impl
```rs
impl<T: PartialEq<U>, U> PartialEq<ArchivedOption<T>> for Option<U>
```
adds another `PartialEq` candidate, so coercion no longer applies and the literal stays `&[u8; N]`, for which no matching impl exists.

## Fix

Coerce the literals to slices explicitly:
```
extract_attr_value(tag, b"Item:Semantic") == Some(&b"MotionPhoto"[..])
extract_attr_value(tag, b"Item:Mime")     == Some(&b"video/mp4"[..])
```
This makes the comparison type-correct on its own, independent of any other crate in the graph.

## Notes

- No behavior change; purely a type-annotation fix.
- Reproducible by adding rkyv as a dependency to a crate that also uses this one.