### PR TITLE
feat: add WebP (RIFF/WEBP) image EXIF support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **WebP (RIFF/WEBP) image support** — extracts EXIF/GPS from the
+  `EXIF` chunk via the unified `parse_exif` / `read_exif` (sync +
+  async) APIs.
+
 ## nom-exif v3.6.1 (2026-06-11)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ track metadata** through a single unified API. Built on
 
 ## Supported File Types
 
-- **Image**: JPEG, PNG, HEIC/HEIF, AVIF, TIFF, Phase One IIQ, Fujifilm RAF, Canon CR3
+- **Image**: JPEG, PNG, WebP, HEIC/HEIF, AVIF, TIFF, Phase One IIQ, Fujifilm RAF, Canon CR3
 - **Video/Audio**: MP4, MOV, 3GP (ISOBMFF); MKV, WEBM, MKA (Matroska)
 
 ## Quick Start

--- a/docs/superpowers/plans/2026-07-07-webp-support.md
+++ b/docs/superpowers/plans/2026-07-07-webp-support.md
@@ -1,0 +1,931 @@
+# WebP EXIF Support Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add WebP image EXIF/GPS extraction to `nom-exif`, wired into the existing unified `parse_exif` / `read_exif` (sync + async) APIs.
+
+**Architecture:** WebP is a RIFF container (`"RIFF"` + fileSize(LE u32) + `"WEBP"`, then FourCC-tagged chunks). EXIF lives in an `EXIF` chunk (raw TIFF) *after* the image bitstream. Rather than a PNG-style special-case path, WebP rides the **generic** EXIF path: a pure walker `webp::extract_exif(state, buf) -> Result<(Option<&[u8]>, Option<ParsingState>), ParsingErrorState>` slots into `exif::extract_exif_with_mime`, reusing `extract_exif_range`, `range_to_iter`, and both the sync and async drivers with zero async-specific code. The walker bounds itself by the RIFF size field (WebP has no terminator chunk), skipping large non-EXIF chunks via `ClearAndSkip`.
+
+**Tech Stack:** Rust, `nom`, `bytes::Bytes` (zero-copy buffer sharing), `tokio` (optional async feature), `test-case` (parameterized tests).
+
+---
+
+## Refinement over the spec
+
+The spec described `ParsingState::WebpPastHeader` as a unit variant (mirroring PNG's `PngPastSignature`). During code-level design one change was needed: **WebP has no explicit terminator chunk** (PNG stops at `IEND`), so the walker must stop when it reaches the end of the RIFF chunk region declared by the header's size field. That bound (bytes remaining in the chunk stream) must survive a `ClearAndSkip` that re-anchors the buffer, so the variant carries it: **`WebpPastHeader(usize)`**. Without this, a valid WebP with no EXIF would loop `Need` until the driver hit EOF and surface a read *error* instead of a clean `Error::ExifNotFound`.
+
+## File Structure
+
+- **Create** `src/webp.rs` — pure RIFF chunk walker; extracts the `EXIF` chunk payload. One responsibility: WebP byte structure → EXIF slice. Self-contained unit tests.
+- **Modify** `src/error.rs` — add `MalformedKind::WebpChunk`.
+- **Modify** `src/parser.rs` — add `ParsingState::WebpPastHeader(usize)` (+ `Display`); extend small-file EOF tolerance from `Png` to `Png | Webp`.
+- **Modify** `src/file.rs` — add `MediaMimeImage::Webp`, `check_webp`, wire into MIME detection.
+- **Modify** `src/exif.rs` — dispatch `MediaMimeImage::Webp` to `webp::extract_exif`; handle the new `ParsingState` arm.
+- **Modify** `src/lib.rs` — declare `mod webp;`.
+- **Modify** `README.md`, `CHANGELOG.md` — docs.
+
+Task order keeps the crate compiling and green after every task.
+
+---
+
+### Task 1: Add `MalformedKind::WebpChunk`
+
+**Files:**
+- Modify: `src/error.rs:200-207` (enum), `src/error.rs:209-221` (Display), `src/error.rs:287-298` (coverage test)
+
+- [ ] **Step 1: Extend the coverage test to require the new variant**
+
+In `src/error.rs`, add `MalformedKind::WebpChunk` to the array in `malformed_kind_covers_all_structural_units`:
+
+```rust
+    #[test]
+    fn malformed_kind_covers_all_structural_units() {
+        for k in [
+            MalformedKind::JpegSegment,
+            MalformedKind::TiffHeader,
+            MalformedKind::IfdEntry,
+            MalformedKind::IsoBmffBox,
+            MalformedKind::EbmlElement,
+            MalformedKind::PngChunk,
+            MalformedKind::WebpChunk,
+        ] {
+            let _ = format!("{k:?}");
+        }
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test --lib error:: 2>&1 | tail -20`
+Expected: FAIL — compile error, `no variant named WebpChunk found for enum MalformedKind`.
+
+- [ ] **Step 3: Add the variant and its Display arm**
+
+In the `MalformedKind` enum (after `PngChunk`):
+
+```rust
+pub enum MalformedKind {
+    JpegSegment,
+    TiffHeader,
+    IfdEntry,
+    IsoBmffBox,
+    EbmlElement,
+    PngChunk,
+    WebpChunk,
+}
+```
+
+In `impl std::fmt::Display for MalformedKind`, add to the match (after the `PngChunk` arm):
+
+```rust
+            Self::PngChunk => "png chunk",
+            Self::WebpChunk => "webp chunk",
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cargo test --lib error:: 2>&1 | tail -20`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/error.rs
+git commit -m "feat: add MalformedKind::WebpChunk"
+```
+
+---
+
+### Task 2: Add `ParsingState::WebpPastHeader(usize)`
+
+**Files:**
+- Modify: `src/parser.rs:501-521` (enum + Display)
+- Modify: `src/exif.rs:248-253` (state→header match in `extract_exif_range`)
+
+This is plumbing so later tasks compile. `ParsingState` is an exhaustive-matched enum, so every `match` over it must gain an arm. The two known sites are below; if `cargo build` flags another, add `ParsingState::WebpPastHeader(_) => None` (or the context-appropriate arm) there too.
+
+- [ ] **Step 1: Add the enum variant**
+
+In `src/parser.rs`, in `pub(crate) enum ParsingState` (after `PngPastSignature`):
+
+```rust
+pub(crate) enum ParsingState {
+    TiffHeader(TiffHeader),
+    HeifExifSize(usize),
+    Cr3ExifSize(usize),
+    /// PNG chunk walker has already validated the 8-byte signature.
+    PngPastSignature,
+    /// WebP RIFF walker has validated the 12-byte header and skipped some
+    /// chunks. Carries the number of chunk-stream bytes still remaining
+    /// (from the resumed buffer's start) so the walker can stop cleanly at
+    /// the end of the RIFF chunk region — WebP has no terminator chunk.
+    WebpPastHeader(usize),
+}
+```
+
+- [ ] **Step 2: Add the Display arm**
+
+In `impl Display for ParsingState`, in the match:
+
+```rust
+            ParsingState::PngPastSignature => f.write_str("ParsingState: PngPastSignature"),
+            ParsingState::WebpPastHeader(n) => {
+                Display::fmt(&format!("ParsingState: WebpPastHeader({n})"), f)
+            }
+```
+
+- [ ] **Step 3: Add the `extract_exif_range` arm**
+
+In `src/exif.rs`, in `extract_exif_range`, the `state.and_then(|x| match x { ... })` block (around line 248):
+
+```rust
+    let header = state.and_then(|x| match x {
+        ParsingState::TiffHeader(h) => Some(h),
+        ParsingState::HeifExifSize(_) => None,
+        ParsingState::Cr3ExifSize(_) => None,
+        ParsingState::PngPastSignature => None,
+        ParsingState::WebpPastHeader(_) => None,
+    });
+```
+
+- [ ] **Step 4: Verify the crate still builds**
+
+Run: `cargo build 2>&1 | tail -20`
+Expected: builds clean (a `WebpPastHeader` never-constructed dead-code note is acceptable until Task 4 wires it).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/parser.rs src/exif.rs
+git commit -m "feat: add ParsingState::WebpPastHeader(usize)"
+```
+
+---
+
+### Task 3: WebP MIME detection
+
+**Files:**
+- Modify: `src/file.rs:59-69` (enum), `src/file.rs:91-101` (TryFrom chain), `src/file.rs:231-239` (near `check_png`), `src/file.rs` tests
+
+Adding `MediaMimeImage::Webp` makes the exhaustive match in `exif::extract_exif_with_mime` incomplete — **Task 4 adds that arm**. To keep this task compiling on its own, add a temporary `unreachable!` arm here and replace it in Task 4.
+
+- [ ] **Step 1: Write the failing detection test**
+
+In `src/file.rs`, inside `mod v3_tests` (near the bottom, `use super::*;` already present there), add:
+
+```rust
+    #[test]
+    fn webp_riff_header_detected_as_image() {
+        // Minimal RIFF/WEBP header + one chunk header's worth of bytes.
+        let mut buf = Vec::new();
+        buf.extend_from_slice(b"RIFF");
+        buf.extend_from_slice(&16u32.to_le_bytes()); // riff size (value irrelevant to detection)
+        buf.extend_from_slice(b"WEBP");
+        buf.extend_from_slice(b"VP8X");
+        buf.extend_from_slice(&[0u8; 4]);
+        let res: Result<MediaMime, Error> = buf.as_slice().try_into();
+        assert!(matches!(res, Ok(MediaMime::Image(MediaMimeImage::Webp))));
+    }
+
+    #[test]
+    fn riff_without_webp_fourcc_is_not_webp() {
+        // A RIFF/WAVE header must NOT be misdetected as WebP.
+        let mut buf = Vec::new();
+        buf.extend_from_slice(b"RIFF");
+        buf.extend_from_slice(&16u32.to_le_bytes());
+        buf.extend_from_slice(b"WAVE");
+        buf.extend_from_slice(&[0u8; 8]);
+        let res: Result<MediaMime, Error> = buf.as_slice().try_into();
+        assert!(matches!(res, Err(Error::UnsupportedFormat)));
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test --lib file:: 2>&1 | tail -20`
+Expected: FAIL — compile error, `no variant named Webp found for enum MediaMimeImage`.
+
+- [ ] **Step 3: Add the enum variant**
+
+In `src/file.rs`, in `pub(crate) enum MediaMimeImage` (after `Png`):
+
+```rust
+pub(crate) enum MediaMimeImage {
+    Jpeg,
+    Heic,
+    Heif,
+    Avif,
+    Tiff,
+    Raf,
+    Cr3,
+    Png,
+    Webp,
+}
+```
+
+- [ ] **Step 4: Add `check_webp` and wire it into the TryFrom chain**
+
+In `src/file.rs`, add near `check_png` (after the `check_png` fn, around line 239):
+
+```rust
+fn check_webp(input: &[u8]) -> Result<(), ()> {
+    // RIFF container tagged WEBP: "RIFF"(4) + fileSize(4) + "WEBP"(4).
+    if input.len() >= 12 && &input[0..4] == b"RIFF" && &input[8..12] == b"WEBP" {
+        Ok(())
+    } else {
+        Err(())
+    }
+}
+```
+
+In `impl TryFrom<&[u8]> for MediaMime`, add a branch after the `check_png` branch:
+
+```rust
+        } else if check_png(input).is_ok() {
+            MediaMime::Image(MediaMimeImage::Png)
+        } else if check_webp(input).is_ok() {
+            MediaMime::Image(MediaMimeImage::Webp)
+        } else if check_jpeg(input).is_ok() {
+```
+
+- [ ] **Step 5: Add the temporary exhaustive-match arm so the crate compiles**
+
+In `src/exif.rs`, in `extract_exif_with_mime`'s match (after the `MediaMimeImage::Png => { ... }` arm, around line 400), add:
+
+```rust
+        MediaMimeImage::Webp => {
+            // Wired to the real walker in the next task.
+            unreachable!("WebP dispatch not yet wired");
+        }
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `cargo test --lib file:: 2>&1 | tail -20`
+Expected: PASS (both new tests green).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/file.rs src/exif.rs
+git commit -m "feat: detect WebP (RIFF/WEBP) as an image MIME"
+```
+
+---
+
+### Task 4: WebP chunk walker (`src/webp.rs`)
+
+**Files:**
+- Create: `src/webp.rs`
+- Modify: `src/lib.rs:365` (add `mod webp;` after `mod png;`)
+
+The walker is the core. It is a pure function tested in isolation via synthetic buffers before any dispatch wiring (Task 5) uses it.
+
+- [ ] **Step 1: Create `src/webp.rs` with the walker and its unit tests**
+
+Create `src/webp.rs` with this exact content:
+
+```rust
+//! WebP (RIFF) chunk parser — pure-function EXIF extractor.
+//!
+//! WebP is a RIFF container: `"RIFF"` + fileSize(LE u32) + `"WEBP"`, then a
+//! sequence of chunks (`FourCC` + size(LE u32) + payload + one pad byte when
+//! size is odd). EXIF lives in an `EXIF` chunk (raw TIFF), present only in
+//! extended (VP8X) files, and sits *after* the image bitstream — so the
+//! walker must skip potentially-large `VP8 `/`VP8L`/`ANMF` chunks to reach it.
+//!
+//! Unlike PNG there is no terminator chunk, so the walk is bounded by the
+//! RIFF size field. That bound (bytes left in the chunk region) is threaded
+//! across a `ClearAndSkip` via [`ParsingState::WebpPastHeader`] so the walker
+//! stops cleanly (`Ok(None)` → `ExifNotFound`) instead of reading to EOF.
+//!
+//! Stateless and pure: operates on a `&[u8]` buffer plus the resume-state
+//! from any prior call. The caller (`MediaParser`) drives all I/O.
+
+use crate::error::{MalformedKind, ParsingError, ParsingErrorState};
+use crate::parser::ParsingState;
+
+const WEBP_HEADER_LEN: usize = 12; // "RIFF" + size(4) + "WEBP"
+const CHUNK_HEADER_LEN: usize = 8; // FourCC(4) + size(4)
+
+/// Walk the RIFF chunk stream and return the `EXIF` chunk payload (raw TIFF),
+/// borrowed from `buf`, if present.
+///
+/// `state` is `Some(WebpPastHeader(stream_left))` only after a `ClearAndSkip`:
+/// `buf[0]` is then a chunk boundary rather than the 12-byte file header, and
+/// `stream_left` is the number of chunk-region bytes remaining from `buf[0]`.
+pub(crate) fn extract_exif(
+    state: Option<ParsingState>,
+    buf: &[u8],
+) -> Result<(Option<&[u8]>, Option<ParsingState>), ParsingErrorState> {
+    // (cursor start, chunk-region bytes remaining from cursor)
+    let (mut cursor, mut stream_left) = match state {
+        Some(ParsingState::WebpPastHeader(left)) => (0usize, left),
+        _ => {
+            if buf.len() < WEBP_HEADER_LEN {
+                return Err(ParsingErrorState::new(
+                    ParsingError::Need(WEBP_HEADER_LEN - buf.len()),
+                    None,
+                ));
+            }
+            if &buf[0..4] != b"RIFF" || &buf[8..12] != b"WEBP" {
+                return Err(ParsingErrorState::new(
+                    ParsingError::Failed {
+                        kind: MalformedKind::WebpChunk,
+                        message: "WebP: bad RIFF/WEBP header".into(),
+                    },
+                    None,
+                ));
+            }
+            // RIFF size = whole file minus 8 ("RIFF" + size field). The chunk
+            // region is everything after the "WEBP" FourCC, i.e. riff_size - 4.
+            let riff_size =
+                u32::from_le_bytes([buf[4], buf[5], buf[6], buf[7]]) as usize;
+            (WEBP_HEADER_LEN, riff_size.saturating_sub(4))
+        }
+    };
+
+    // Preserve the resume bound across `Need` returns (buffer only grows).
+    let preserve = |left: usize| Some(ParsingState::WebpPastHeader(left));
+
+    loop {
+        // No room in the declared chunk region for another chunk header → done.
+        if stream_left < CHUNK_HEADER_LEN {
+            return Ok((None, Some(ParsingState::WebpPastHeader(stream_left))));
+        }
+        // Buffer doesn't yet hold the next chunk header — ask for more bytes.
+        let in_buf = buf.len() - cursor;
+        if in_buf < CHUNK_HEADER_LEN {
+            return Err(ParsingErrorState::new(
+                ParsingError::Need(CHUNK_HEADER_LEN - in_buf),
+                preserve(stream_left),
+            ));
+        }
+
+        let fourcc = &buf[cursor..cursor + 4];
+        let size = u32::from_le_bytes([
+            buf[cursor + 4],
+            buf[cursor + 5],
+            buf[cursor + 6],
+            buf[cursor + 7],
+        ]);
+        // total = header(8) + payload(size) + pad(1 if size is odd).
+        let pad = (size & 1) as usize;
+        let total = match (size as usize).checked_add(CHUNK_HEADER_LEN + pad) {
+            Some(t) => t,
+            None => {
+                return Err(ParsingErrorState::new(
+                    ParsingError::Failed {
+                        kind: MalformedKind::WebpChunk,
+                        message: "WebP: chunk size overflows addressable size".into(),
+                    },
+                    preserve(stream_left),
+                ));
+            }
+        };
+
+        if fourcc == b"EXIF" {
+            if total > in_buf {
+                return Err(ParsingErrorState::new(
+                    ParsingError::Need(total - in_buf),
+                    preserve(stream_left),
+                ));
+            }
+            let data_start = cursor + CHUNK_HEADER_LEN;
+            let data_end = data_start + size as usize;
+            let mut payload = &buf[data_start..data_end];
+            // Some encoders wrongly prepend the JPEG APP1 "Exif\0\0" marker.
+            if payload.starts_with(b"Exif\0\0") {
+                payload = &payload[6..];
+            }
+            return Ok((Some(payload), preserve(stream_left)));
+        }
+
+        // Chunk claims more than the RIFF container allows — treat as the end
+        // of useful data rather than skipping past EOF.
+        if total > stream_left {
+            return Ok((None, Some(ParsingState::WebpPastHeader(0))));
+        }
+
+        // Non-EXIF chunk. If it isn't fully buffered, skip it whole: advance
+        // the parser by `cursor + total` (bytes walked in `buf` plus this
+        // chunk) and resume past the header with the reduced bound.
+        if total > in_buf {
+            return Err(ParsingErrorState::new(
+                ParsingError::ClearAndSkip(cursor + total),
+                Some(ParsingState::WebpPastHeader(stream_left - total)),
+            ));
+        }
+        cursor += total;
+        stream_left -= total;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Minimal little-endian TIFF: II + 0x002A + IFD0 offset 8 + empty IFD0.
+    fn minimal_tiff_le() -> Vec<u8> {
+        let mut t = Vec::new();
+        t.extend_from_slice(b"II");
+        t.extend_from_slice(&[0x2a, 0x00]);
+        t.extend_from_slice(&[0x08, 0, 0, 0]);
+        t.extend_from_slice(&[0, 0]);
+        t.extend_from_slice(&[0, 0, 0, 0]);
+        t
+    }
+
+    fn chunk(fourcc: &[u8; 4], data: &[u8]) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend_from_slice(fourcc);
+        out.extend_from_slice(&(data.len() as u32).to_le_bytes());
+        out.extend_from_slice(data);
+        if data.len() % 2 == 1 {
+            out.push(0); // pad to even
+        }
+        out
+    }
+
+    /// Wrap chunk bytes in a RIFF/WEBP container with a correct size field.
+    fn webp(chunks: &[Vec<u8>]) -> Vec<u8> {
+        let mut body = Vec::new();
+        body.extend_from_slice(b"WEBP");
+        for c in chunks {
+            body.extend_from_slice(c);
+        }
+        let mut out = Vec::new();
+        out.extend_from_slice(b"RIFF");
+        out.extend_from_slice(&(body.len() as u32).to_le_bytes());
+        out.extend_from_slice(&body);
+        out
+    }
+
+    #[test]
+    fn no_exif_returns_none() {
+        let buf = webp(&[chunk(b"VP8X", &[0u8; 10])]);
+        let (exif, _) = extract_exif(None, &buf).unwrap();
+        assert!(exif.is_none());
+    }
+
+    #[test]
+    fn extracts_exif_payload() {
+        let tiff = minimal_tiff_le();
+        let buf = webp(&[chunk(b"VP8X", &[0u8; 10]), chunk(b"EXIF", &tiff)]);
+        let (exif, _) = extract_exif(None, &buf).unwrap();
+        assert_eq!(exif.unwrap(), tiff.as_slice());
+    }
+
+    #[test]
+    fn strips_exif_prefix() {
+        let tiff = minimal_tiff_le();
+        let mut payload = Vec::new();
+        payload.extend_from_slice(b"Exif\0\0");
+        payload.extend_from_slice(&tiff);
+        let buf = webp(&[chunk(b"EXIF", &payload)]);
+        let (exif, _) = extract_exif(None, &buf).unwrap();
+        assert_eq!(exif.unwrap(), tiff.as_slice());
+    }
+
+    #[test]
+    fn odd_length_chunk_padding_accounted() {
+        // A 3-byte VP8X-ish chunk (odd → 1 pad byte) before EXIF. If padding
+        // is miscounted, the EXIF FourCC won't align and extraction fails.
+        let tiff = minimal_tiff_le();
+        let buf = webp(&[chunk(b"ICCP", &[1, 2, 3]), chunk(b"EXIF", &tiff)]);
+        let (exif, _) = extract_exif(None, &buf).unwrap();
+        assert_eq!(exif.unwrap(), tiff.as_slice());
+    }
+
+    #[test]
+    fn bad_header_fails() {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(b"RIFF");
+        buf.extend_from_slice(&16u32.to_le_bytes());
+        buf.extend_from_slice(b"WAVE"); // not WEBP
+        buf.extend_from_slice(&[0u8; 8]);
+        let err = extract_exif(None, &buf).unwrap_err();
+        assert!(matches!(
+            err.err,
+            ParsingError::Failed {
+                kind: MalformedKind::WebpChunk,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn truncated_header_needs_more() {
+        let buf = b"RIFF\x00\x00".to_vec();
+        let err = extract_exif(None, &buf).unwrap_err();
+        assert!(matches!(err.err, ParsingError::Need(_)));
+    }
+
+    #[test]
+    fn large_leading_chunk_clear_and_skips() {
+        // A VP8L chunk declaring 50_000 bytes not present in the buffer must
+        // yield ClearAndSkip(cursor + total) + WebpPastHeader(remaining).
+        let mut buf = Vec::new();
+        buf.extend_from_slice(b"RIFF");
+        // riff_size large enough to contain the declared chunk + an EXIF later.
+        buf.extend_from_slice(&1_000_000u32.to_le_bytes());
+        buf.extend_from_slice(b"WEBP");
+        // VP8L header only, claiming 50_000 bytes of body.
+        buf.extend_from_slice(b"VP8L");
+        buf.extend_from_slice(&50_000u32.to_le_bytes());
+        let err = extract_exif(None, &buf).unwrap_err();
+        match err.err {
+            // cursor at skip time = 12 (header); total = 8 + 50_000 (+0 pad).
+            ParsingError::ClearAndSkip(n) => assert_eq!(n, 12 + 8 + 50_000),
+            other => panic!("expected ClearAndSkip, got {other:?}"),
+        }
+        assert!(matches!(err.state, Some(ParsingState::WebpPastHeader(_))));
+    }
+
+    #[test]
+    fn resumes_past_header_finds_exif() {
+        // Simulate the post-ClearAndSkip resume: buf starts at a chunk
+        // boundary (no RIFF header), state carries the remaining bound.
+        let tiff = minimal_tiff_le();
+        let exif_chunk = chunk(b"EXIF", &tiff);
+        let stream_left = exif_chunk.len();
+        let (exif, _) = extract_exif(
+            Some(ParsingState::WebpPastHeader(stream_left)),
+            &exif_chunk,
+        )
+        .unwrap();
+        assert_eq!(exif.unwrap(), tiff.as_slice());
+    }
+
+    #[test]
+    fn size_max_does_not_panic() {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(b"RIFF");
+        buf.extend_from_slice(&u32::MAX.to_le_bytes());
+        buf.extend_from_slice(b"WEBP");
+        buf.extend_from_slice(b"VP8L");
+        buf.extend_from_slice(&u32::MAX.to_le_bytes());
+        // Any of Ok(None)/Need/ClearAndSkip/Failed is fine; the contract is
+        // "no panic, no wrap-around, no infinite loop".
+        let _ = extract_exif(None, &buf);
+    }
+}
+```
+
+- [ ] **Step 2: Declare the module**
+
+In `src/lib.rs`, after `mod png;` (line 365):
+
+```rust
+mod png;
+mod webp;
+```
+
+- [ ] **Step 3: Run the walker unit tests to verify they pass**
+
+Run: `cargo test --lib webp:: 2>&1 | tail -25`
+Expected: PASS — all `webp::tests::*` green. (A dead-code note for `extract_exif` is acceptable; Task 5 wires it.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/webp.rs src/lib.rs
+git commit -m "feat: add WebP RIFF chunk walker (webp::extract_exif)"
+```
+
+---
+
+### Task 5: Wire WebP into the generic EXIF dispatch + EOF tolerance
+
+**Files:**
+- Modify: `src/exif.rs:396-400` (replace the temporary `unreachable!` arm)
+- Modify: `src/parser.rs` (EOF tolerance: `parse_exif` ~804-807, `parse_image_metadata` ~975, `parse_exif_async` ~1094-1097, `parse_image_metadata_async` ~1146)
+- Modify: `src/exif.rs` (add `webp` to imports if needed)
+- Test: end-to-end sync test in `src/parser.rs` tests module
+
+- [ ] **Step 1: Write the failing end-to-end test**
+
+In `src/parser.rs`, inside the existing `#[cfg(test)] mod ...` that holds `parse_exif_unified_from_memory_jpg`, add these helpers + test. (They build a synthetic WebP entirely in memory — no sample file needed.)
+
+```rust
+    // --- WebP synthetic-buffer helpers (mirrors src/webp.rs test builders) ---
+    #[cfg(test)]
+    fn webp_minimal_tiff_le() -> Vec<u8> {
+        // II + 0x002A + IFD0 offset 8 + IFD0 with one tag (Make="A") + next=0.
+        let mut t = Vec::new();
+        t.extend_from_slice(b"II");
+        t.extend_from_slice(&[0x2a, 0x00]);
+        t.extend_from_slice(&[0x08, 0, 0, 0]); // IFD0 at offset 8
+        t.extend_from_slice(&[0x01, 0x00]); // 1 entry
+        // Tag 0x010F (Make), type 2 (ASCII), count 2, inline value "A\0".
+        t.extend_from_slice(&[0x0f, 0x01]); // tag 0x010F
+        t.extend_from_slice(&[0x02, 0x00]); // type ASCII
+        t.extend_from_slice(&[0x02, 0x00, 0x00, 0x00]); // count 2
+        t.extend_from_slice(b"A\0\0\0"); // value "A\0" padded to 4 bytes
+        t.extend_from_slice(&[0, 0, 0, 0]); // next IFD = 0
+        t
+    }
+
+    #[cfg(test)]
+    fn webp_with_exif(tiff: &[u8]) -> Vec<u8> {
+        let mut exif_chunk = Vec::new();
+        exif_chunk.extend_from_slice(b"EXIF");
+        exif_chunk.extend_from_slice(&(tiff.len() as u32).to_le_bytes());
+        exif_chunk.extend_from_slice(tiff);
+        if tiff.len() % 2 == 1 {
+            exif_chunk.push(0);
+        }
+        let mut vp8x = Vec::new();
+        vp8x.extend_from_slice(b"VP8X");
+        vp8x.extend_from_slice(&10u32.to_le_bytes());
+        vp8x.extend_from_slice(&[0u8; 10]);
+
+        let mut body = Vec::new();
+        body.extend_from_slice(b"WEBP");
+        body.extend_from_slice(&vp8x);
+        body.extend_from_slice(&exif_chunk);
+
+        let mut out = Vec::new();
+        out.extend_from_slice(b"RIFF");
+        out.extend_from_slice(&(body.len() as u32).to_le_bytes());
+        out.extend_from_slice(&body);
+        out
+    }
+
+    #[test]
+    fn parse_exif_webp_from_memory() {
+        let tiff = webp_minimal_tiff_le();
+        let buf = webp_with_exif(&tiff);
+        let mut parser = MediaParser::new();
+        let ms = MediaSource::from_memory(buf).unwrap();
+        let iter = parser.parse_exif(ms).unwrap();
+        let exif: crate::Exif = iter.into();
+        assert_eq!(
+            exif.get(crate::ExifTag::Make).and_then(|v| v.as_str()),
+            Some("A")
+        );
+    }
+
+    #[test]
+    fn parse_exif_webp_no_exif_returns_not_found() {
+        // RIFF/WEBP with only a VP8X chunk (no EXIF).
+        let mut vp8x = Vec::new();
+        vp8x.extend_from_slice(b"VP8X");
+        vp8x.extend_from_slice(&10u32.to_le_bytes());
+        vp8x.extend_from_slice(&[0u8; 10]);
+        let mut body = Vec::new();
+        body.extend_from_slice(b"WEBP");
+        body.extend_from_slice(&vp8x);
+        let mut buf = Vec::new();
+        buf.extend_from_slice(b"RIFF");
+        buf.extend_from_slice(&(body.len() as u32).to_le_bytes());
+        buf.extend_from_slice(&body);
+
+        let mut parser = MediaParser::new();
+        let ms = MediaSource::from_memory(buf).unwrap();
+        let res = parser.parse_exif(ms);
+        assert!(matches!(res, Err(crate::Error::ExifNotFound)));
+    }
+
+    #[test]
+    fn parse_exif_webp_streaming_small_file() {
+        // Exercises the Png|Webp small-file EOF tolerance on the streaming
+        // path: a sub-INIT_BUF_SIZE WebP fully consumed during MIME prefill.
+        use std::io::Cursor;
+        let tiff = webp_minimal_tiff_le();
+        let buf = webp_with_exif(&tiff);
+        let mut parser = MediaParser::new();
+        let ms = MediaSource::seekable(Cursor::new(buf)).unwrap();
+        let iter = parser.parse_exif(ms).unwrap();
+        let exif: crate::Exif = iter.into();
+        assert_eq!(
+            exif.get(crate::ExifTag::Make).and_then(|v| v.as_str()),
+            Some("A")
+        );
+    }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cargo test --lib parse_exif_webp 2>&1 | tail -30`
+Expected: FAIL — `parse_exif_webp_from_memory` panics via the `unreachable!("WebP dispatch not yet wired")` arm from Task 3.
+
+- [ ] **Step 3: Replace the `unreachable!` arm with the real dispatch**
+
+In `src/exif.rs`, in `extract_exif_with_mime`, replace the temporary WebP arm:
+
+```rust
+        MediaMimeImage::Webp => crate::webp::extract_exif(state, buf)?,
+```
+
+(This returns `(Option<&[u8]>, Option<ParsingState>)`, matching the `let (exif_data, state) = match img_type { ... }` binding — same shape as the `Heic | Heif | Avif` and `Cr3` arms.)
+
+- [ ] **Step 4: Extend the small-file EOF tolerance from Png to Png | Webp**
+
+In `src/parser.rs`, there are four sites that special-case PNG for the "reader exhausted during MIME prefill" case. Update each to also accept WebP.
+
+Site A — `parse_exif` (around line 804):
+
+```rust
+                let is_png_or_webp = matches!(
+                    ms.mime,
+                    crate::file::MediaMime::Image(
+                        crate::file::MediaMimeImage::Png | crate::file::MediaMimeImage::Webp
+                    )
+                );
+                match self.fill_buf(&mut ms.reader, INIT_BUF_SIZE) {
+                    Ok(_) => {}
+                    Err(e)
+                        if is_png_or_webp
+                            && !self.buffer().is_empty()
+                            && e.kind() == io::ErrorKind::UnexpectedEof => {}
+                    Err(e) => return Err(e.into()),
+                }
+```
+
+Site B — `parse_image_metadata` (around line 975): replace
+
+```rust
+                let is_png = mime_img == crate::file::MediaMimeImage::Png;
+```
+
+with
+
+```rust
+                let is_png = matches!(
+                    mime_img,
+                    crate::file::MediaMimeImage::Png | crate::file::MediaMimeImage::Webp
+                );
+```
+
+Site C — `parse_exif_async` (around line 1094): mirror Site A, renaming the local to `is_png_or_webp` and matching `Png | Webp`:
+
+```rust
+                    let is_png_or_webp = matches!(
+                        ms.mime,
+                        crate::file::MediaMime::Image(
+                            crate::file::MediaMimeImage::Png | crate::file::MediaMimeImage::Webp
+                        )
+                    );
+                    match <Self as AsyncBufParser>::fill_buf(self, &mut ms.reader, INIT_BUF_SIZE)
+                        .await
+                    {
+                        Ok(_) => {}
+                        Err(e)
+                            if is_png_or_webp
+                                && !self.buffer().is_empty()
+                                && e.kind() == io::ErrorKind::UnexpectedEof => {}
+                        Err(e) => return Err(e.into()),
+                    }
+```
+
+Site D — `parse_image_metadata_async` (around line 1146): replace
+
+```rust
+                    let is_png = mime_img == crate::file::MediaMimeImage::Png;
+```
+
+with
+
+```rust
+                    let is_png = matches!(
+                        mime_img,
+                        crate::file::MediaMimeImage::Png | crate::file::MediaMimeImage::Webp
+                    );
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cargo test --lib parse_exif_webp 2>&1 | tail -30`
+Expected: PASS — all three WebP end-to-end tests green.
+
+- [ ] **Step 6: Run the full lib test suite to check for regressions**
+
+Run: `cargo test --lib 2>&1 | tail -15`
+Expected: PASS — no regressions.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/exif.rs src/parser.rs
+git commit -m "feat: extract EXIF from WebP images"
+```
+
+---
+
+### Task 6: Async end-to-end test
+
+**Files:**
+- Test: `src/parser.rs` tests module (async test, `#[cfg(feature = "tokio")]`)
+
+- [ ] **Step 1: Write the async end-to-end test**
+
+In `src/parser.rs`, near the existing `media_parser_parse_exif_async` test, add. It reuses the `webp_minimal_tiff_le` / `webp_with_exif` helpers from Task 5.
+
+```rust
+    #[cfg(feature = "tokio")]
+    #[tokio::test]
+    async fn parse_exif_webp_async_from_memory() {
+        use crate::AsyncMediaSource;
+        let tiff = webp_minimal_tiff_le();
+        let buf = webp_with_exif(&tiff);
+        let mut parser = MediaParser::new();
+        let ms = AsyncMediaSource::from_memory(buf).unwrap();
+        let iter = parser.parse_exif_async(ms).await.unwrap();
+        let exif: crate::Exif = iter.into();
+        assert_eq!(
+            exif.get(crate::ExifTag::Make).and_then(|v| v.as_str()),
+            Some("A")
+        );
+    }
+```
+
+Note: `AsyncMediaSource::from_memory` is synchronous (returns `crate::Result<Self>`, no `.await`); only `parse_exif_async` is awaited. This matches the existing `AsyncMediaSource::from_memory(raw).unwrap()` usage in the test module.
+
+- [ ] **Step 2: Run the async test to verify it passes**
+
+Run: `cargo test --lib --features tokio parse_exif_webp_async 2>&1 | tail -20`
+Expected: PASS. (No production code change needed — the async generic path already routes through `extract_exif_with_mime`. If it fails to compile on the `from_memory` call shape, fix per the note in Step 1.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/parser.rs
+git commit -m "test: WebP EXIF via async parse path"
+```
+
+---
+
+### Task 7: Documentation
+
+**Files:**
+- Modify: `README.md:36` (Supported File Types)
+- Modify: `CHANGELOG.md` (top entry)
+
+- [ ] **Step 1: Update the README supported-types line**
+
+In `README.md`, change the Image line (line 36) from:
+
+```markdown
+- **Image**: JPEG, PNG, HEIC/HEIF, AVIF, TIFF, Phase One IIQ, Fujifilm RAF, Canon CR3
+```
+
+to:
+
+```markdown
+- **Image**: JPEG, PNG, WebP, HEIC/HEIF, AVIF, TIFF, Phase One IIQ, Fujifilm RAF, Canon CR3
+```
+
+- [ ] **Step 2: Add a CHANGELOG entry**
+
+Open `CHANGELOG.md` and read the top of the file to match its existing format (headings, date style). Add a new entry at the top describing the change, following whatever "Unreleased"/version convention is already used there. The entry text:
+
+```markdown
+- feat: add WebP (RIFF/WEBP) image support — extracts EXIF/GPS from the
+  `EXIF` chunk via the unified `parse_exif` / `read_exif` (sync + async) APIs.
+```
+
+Place it under the existing "Unreleased" section if present, otherwise create one above the most recent released version, matching the file's style.
+
+- [ ] **Step 3: Verify formatting and the full build**
+
+Run: `cargo fmt --check && cargo clippy --all-targets 2>&1 | tail -15`
+Expected: `cargo fmt --check` produces no output (clean); clippy reports no new warnings for `src/webp.rs` or the modified files.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md CHANGELOG.md
+git commit -m "docs: document WebP EXIF support"
+```
+
+---
+
+## Final Verification
+
+- [ ] **Full test suite (default features)**
+
+Run: `cargo test 2>&1 | tail -20`
+Expected: all green.
+
+- [ ] **Full test suite (with tokio)**
+
+Run: `cargo test --features tokio 2>&1 | tail -20`
+Expected: all green, including `parse_exif_webp_async_from_memory`.
+
+- [ ] **Format + lint**
+
+Run: `cargo fmt --check && cargo clippy --all-targets --all-features 2>&1 | tail -20`
+Expected: clean.
+
+## Self-Review Notes (coverage against spec)
+
+- Spec §4.1 (file.rs MIME) → Task 3.
+- Spec §4.2 (webp.rs walker) → Task 4. Walker returns `(Option<&[u8]>, Option<ParsingState>)`, strips `Exif\0\0`, handles Need/ClearAndSkip/Failed, odd-size padding, overflow guard.
+- Spec §4.3 (parser.rs ParsingState + EOF tolerance) → Task 2 (variant) + Task 5 Step 4 (tolerance). Variant carries `usize` (refinement, documented above).
+- Spec §4.4 (exif.rs dispatch + range match) → Task 2 Step 3 (range match) + Task 5 Step 3 (dispatch).
+- Spec §4.5 (lib.rs mod) → Task 4 Step 2.
+- Spec §4.6 (MalformedKind::WebpChunk) → Task 1.
+- Spec §4.7 (docs + tests) → Task 5 (sync e2e), Task 6 (async e2e), Task 7 (README/CHANGELOG).
+- Spec §5 (error handling) → covered by walker (Task 4) + `range_to_iter` (existing) producing `ExifNotFound`, verified by `parse_exif_webp_no_exif_returns_not_found` (Task 5).
+```

--- a/docs/superpowers/specs/2026-07-07-webp-support-design.md
+++ b/docs/superpowers/specs/2026-07-07-webp-support-design.md
@@ -1,0 +1,222 @@
+# WebP EXIF 支持 —— 设计文档
+
+**日期**: 2026-07-07
+**范围**: 为 `nom-exif` 增加 WebP 图像的 EXIF/GPS 元数据支持（仅 EXIF，不含 XMP）。
+
+## 1. 背景与目标
+
+`nom-exif` 通过统一的 `MediaParser` 分发到各格式后端，按检测到的 MIME
+提取 EXIF。目前支持的图像格式为 JPEG、PNG、HEIC/HEIF、AVIF、TIFF、
+Phase One IIQ、Fujifilm RAF、Canon CR3。本设计新增 **WebP**。
+
+目标：
+
+- `MediaSource::open` / `from_memory` 能把 WebP 识别为 `MediaKind::Image`。
+- `parse_exif` / `read_exif`（及其 `_async` 版本）能从 WebP 的 `EXIF`
+  chunk 提取 EXIF，进而支持 `gps_info()` 等既有能力。
+- 无 EXIF 的 WebP 返回 `Error::ExifNotFound`，与其他格式一致。
+
+非目标（本期不做）：
+
+- WebP `XMP ` chunk（作为 `ImageFormatMetadata::Webp` 暴露）—— 留待后续。
+- ICCP、动画帧元数据、写入/编辑。
+
+## 2. WebP 容器格式
+
+WebP 基于 RIFF：
+
+```
+偏移  长度  内容
+0     4     "RIFF"
+4     4     文件大小 - 8 （小端 u32）
+8     4     "WEBP"
+12    ...   一串 chunk
+```
+
+每个 chunk：
+
+```
+0   4   FourCC（如 "VP8 " "VP8L" "VP8X" "ANIM" "ANMF" "ALPH" "ICCP" "EXIF" "XMP "）
+4   4   负载大小（小端 u32，不含补齐字节）
+8   ...  负载（size 字节）
+    ...  若 size 为奇数，补 1 个 0 字节
+```
+
+要点：
+
+- **字节序**：RIFF chunk 大小是**小端**（与 PNG 的大端相反）。
+- **无 CRC**：PNG 每 chunk 有 4 字节 CRC，WebP 没有；奇数长度补 1 字节。
+- **EXIF 负载**：裸 TIFF 流（`II`/`MM` 开头）。个别编码器会误加
+  JPEG APP1 式的 `"Exif\0\0"` 前缀，需防御性剥离。
+- **元数据仅见于扩展格式**：只有 VP8X 文件才有 `EXIF`/`XMP ` chunk；
+  简单格式（`VP8 `/`VP8L` 紧跟 `WEBP`）没有元数据。
+- **EXIF 位于图像码流之后**：遍历时必须跳过可能很大的
+  `VP8 `/`VP8L`/`ANMF` 等 chunk 才能读到 `EXIF`。
+
+## 3. 核心决策：走通用 EXIF 路径（不开 PNG 式特例）
+
+现有 EXIF 提取有两种接线方式：
+
+- **PNG 式特例**：`parse_exif_iter` 顶部特判 → `parse_png_exif_iter`
+  以及一个 `_async` 双胞胎。PNG 需要它，是因为 PNG 还要**额外**返回
+  `tEXt` chunk（自定义输出结构 `PngParseOut`）。
+- **通用路径**：`parse_exif_iter` → `extract_exif_range` →
+  `extract_exif_with_mime`，按 `MediaMimeImage` 匹配，返回
+  `Option<&[u8]>`（EXIF 字节切片），再由 `range_to_iter` 构造
+  `ExifIter`。JPEG/HEIF/TIFF/RAF/CR3(部分) 都走这里。
+
+**决策：WebP 走通用路径。**
+
+因为本期只要 EXIF，遍历器只需返回 EXIF 负载切片，可直接塞进
+`extract_exif_with_mime` 的 match。收益：
+
+- 复用 `extract_exif_range`、`range_to_iter` 以及**同步 + 异步两条**
+  通用驱动 —— **无需编写任何异步专属代码**（对比 PNG 要写两份）。
+- 与其余格式的接线方式完全一致，代码量最小。
+
+**可行性已验证**：通用驱动 `load_and_parse_with_offset` 会把
+`ParsingState` 透传给下一次 `parse` 调用，并把 `ParsingError::ClearAndSkip`
+映射为 `LoopAction::Skip` → `clear_and_skip`。因此 WebP 遍历器返回的
+`ClearAndSkip(n)` + `Some(WebpPastHeader)` 能被正确处理，与 PNG 跳过大
+`IDAT` 的机制同源。
+
+### `ClearAndSkip` 语义（沿用 PNG 约定）
+
+`ClearAndSkip(n)` 含义为「从解析器当前逻辑位置再前进 n 字节」。闭包
+看到的 `buf` 已偏移到该位置，所以跳过量必须**同时**覆盖遍历器在 `buf`
+内已消费的字节（`cursor`）和还在 buf 之外的 chunk 字节，即
+`cursor + total`，而非 `total - remaining`。
+
+## 4. 组件拆解
+
+### 4.1 `src/file.rs` —— MIME 检测
+
+- 在 `MediaMimeImage` 枚举新增 `Webp` 变体。
+- 新增 `check_webp(input: &[u8]) -> Result<(), ()>`：要求
+  `input.len() >= 12 && &input[0..4] == b"RIFF" && &input[8..12] == b"WEBP"`。
+- 接入 `TryFrom<&[u8]> for MediaMime` 的检测链（放在 `check_png` /
+  `check_jpeg` 附近，各签名互不冲突，顺序无关紧要）：
+  `else if check_webp(input).is_ok() { MediaMime::Image(MediaMimeImage::Webp) }`。
+- 在 `file.rs` 的 `#[cfg(test)] mod tests` 内加一个用合成字节头断言
+  `Image(Webp)` 的用例（无需外部样本文件）。
+
+### 4.2 `src/webp.rs`（新文件）—— 纯函数遍历器
+
+签名与其他格式的 `extract_exif` 对齐：
+
+```rust
+pub(crate) fn extract_exif(
+    state: Option<ParsingState>,
+    buf: &[u8],
+) -> Result<(Option<&[u8]>, Option<ParsingState>), ParsingErrorState>
+```
+
+行为：
+
+1. **文件头**：若 `state` 不是 `WebpPastHeader`，校验前 12 字节
+   （`RIFF`…`WEBP`）；不足 12 字节 → `Need`；签名错 →
+   `Failed { kind: WebpChunk }`。`cursor` 从 12 开始。若是
+   `WebpPastHeader`（ClearAndSkip 之后 resume），`cursor` 从 0 开始，
+   不再校验文件头。
+2. **遍历 chunk**：每次先确保有 8 字节 chunk 头，否则 `Need`。读取
+   FourCC 与小端 size；`total = 8 + size + (size & 1)`，用
+   `checked_add` 防 32 位溢出（溢出 → `Failed`）。
+   - `b"EXIF"`：若 `total > remaining` → `Need(total - remaining)`；
+     否则取负载 `buf[cursor+8 .. cursor+8+size]`，若以 `b"Exif\0\0"`
+     开头则剥掉前 6 字节，返回 `(Some(payload_slice), preserve_state)`。
+   - 其他 FourCC：若 `total > remaining` →
+     `ClearAndSkip(cursor + total)` 并回传 `Some(WebpPastHeader)`；
+     否则 `cursor += total` 继续。
+   - 走到 buf 末尾仍未找到 EXIF 且 chunk 已读完 → 返回
+     `(None, preserve_state)`（由上层转成 `ExifNotFound`）。
+3. 防御上限：对单个非 EXIF chunk 的大小不设人为上限（靠
+   `ClearAndSkip` 流式跳过）；`checked_add` 保证不 panic、不回绕。
+
+注意返回的 `Some(payload_slice)` 是 `buf` 的子切片（剥前缀也仍在 buf
+内），上层 `extract_exif_range` 用 `buf.subslice_in_range` 得到
+`Range`，再由 `range_to_iter` 在共享 `Bytes` 上零拷贝切片。
+
+单元测试（照搬 `png.rs` 的合成构造器）：
+
+- 最小 `RIFF/WEBP`（无 chunk 或仅 VP8X）→ `None`。
+- 含 `EXIF` chunk → 返回正确负载切片。
+- 含带 `Exif\0\0` 前缀的 `EXIF` → 前缀被剥离。
+- 前面有大的 `VP8L`（不在 buf 内）→ `ClearAndSkip(cursor+total)` +
+  `WebpPastHeader`。
+- resume（`state = Some(WebpPastHeader)`，buf 从 chunk 边界开始）→
+  不校验文件头，正常解析后续 chunk。
+- 文件头被截断 → `Need`；签名错 → `Failed`。
+- 奇数长度 chunk 的补齐字节被正确计入 `total`。
+- `size = u32::MAX` → 不 panic（`Need`/`ClearAndSkip`/`Failed` 皆可）。
+
+### 4.3 `src/parser.rs`
+
+- `ParsingState` 枚举新增 `WebpPastHeader`（语义对标
+  `PngPastSignature`：ClearAndSkip 之后告诉下一次调用 buf 不再以 12 字节
+  文件头开头）。
+- `impl Display for ParsingState` 新增对应分支。
+- 小文件预填充 EOF 容忍：现有逻辑对 PNG 特判
+  （`matches!(ms.mime, Image(Png))`），因为极小的 tEXt-only PNG 会在
+  MIME 预填充阶段被读空、`fill_buf` 返回 `UnexpectedEof`。合成的最小
+  WebP 同样很小，故把这些判断从 `Png` 扩展为 `Png | Webp`。涉及 4 处：
+  - `parse_exif`（同步）
+  - `parse_image_metadata`（同步）
+  - `parse_exif_async`
+  - `parse_image_metadata_async`
+
+### 4.4 `src/exif.rs`
+
+- 在 `extract_exif_with_mime` 的 match 新增：
+  `MediaMimeImage::Webp => webp::extract_exif(state, buf)?`（形态与
+  `heif_extract_exif` / `cr3_extract_exif` 一致，返回
+  `(Option<&[u8]>, Option<ParsingState>)`）。
+- 在 `extract_exif_range` 的 state→header 匹配新增
+  `ParsingState::WebpPastHeader => None`（WebP EXIF 是裸 TIFF，
+  `input_into_iter` 自行解析 TIFF 头，header 传 None）。
+- 加入 `use crate::webp;`（或以 `crate::webp::` 全路径调用）。
+
+### 4.5 `src/lib.rs`
+
+- 新增 `mod webp;`（crate 私有，和 `mod png;` 一致）。
+
+### 4.6 `src/error.rs`
+
+- `MalformedKind` 新增 `WebpChunk` 变体（对标 `PngChunk`），并在其
+  `Display`/描述表补上 `"webp chunk"`，避免 WebP 结构错误被误标。
+
+### 4.7 文档与测试
+
+- **README.md**：`Supported File Types` 的 Image 一行加入 WebP。
+- **CHANGELOG.md**：新增条目，说明新增 WebP EXIF 支持。
+- **端到端测试**：拼一个合成的 `RIFF/WEBP + VP8X + EXIF(裸 TIFF)`
+  缓冲区，用 `MediaSource::from_memory` 跑 `parse_exif`（同步），断言能
+  读到 EXIF；若开启 `tokio` feature，再用 `AsyncMediaSource::from_memory`
+  跑 `parse_exif_async` 双胞胎，证明共享的通用路径同步/异步两侧都通。
+  合成 TIFF 可复用最小 LE TIFF（`II` + 0x002A + IFD0 偏移 8 + 空 IFD0），
+  参照 `png.rs` 测试里的 `minimal_tiff_le`。
+
+## 5. 错误处理
+
+| 情况 | 行为 |
+|------|------|
+| 无 `EXIF` chunk | `Error::ExifNotFound`（经 `range_to_iter`） |
+| RIFF 文件头损坏/签名错 | `ParsingError::Failed { kind: WebpChunk, .. }` |
+| chunk 头/负载被截断 | `ParsingError::Need(n)`，驱动补字节后重试 |
+| 大的非 EXIF chunk 不在 buf 内 | `ParsingError::ClearAndSkip(cursor+total)` |
+| `size` 溢出 usize（32 位） | `ParsingError::Failed { kind: WebpChunk, .. }` |
+
+## 6. 兼容性
+
+- 纯新增：`MediaMimeImage`、`ParsingState`、`MalformedKind` 均为
+  crate 私有枚举，新增变体不影响公有 API。
+- `ImageFormatMetadata` 已标 `#[non_exhaustive]`，未来加 `Webp(...)`
+  变体不破坏用户的 `match`（本期不加）。
+- 无新增依赖，保持纯 Rust、可交叉编译。
+
+## 7. 验证清单
+
+- `cargo fmt --check`、`cargo clippy`、`cargo test` 全绿。
+- `webp.rs` 单测覆盖上文列出的各分支。
+- `file.rs` mime 检测测试通过。
+- 端到端同步 + 异步测试通过。
+- README / CHANGELOG 更新到位。

--- a/src/error.rs
+++ b/src/error.rs
@@ -204,6 +204,7 @@ pub enum MalformedKind {
     IsoBmffBox,
     EbmlElement,
     PngChunk,
+    WebpChunk,
 }
 
 impl std::fmt::Display for MalformedKind {
@@ -215,6 +216,7 @@ impl std::fmt::Display for MalformedKind {
             Self::IsoBmffBox => "iso-bmff box",
             Self::EbmlElement => "ebml element",
             Self::PngChunk => "png chunk",
+            Self::WebpChunk => "webp chunk",
         };
         f.write_str(s)
     }
@@ -292,6 +294,7 @@ mod tests {
             MalformedKind::IsoBmffBox,
             MalformedKind::EbmlElement,
             MalformedKind::PngChunk,
+            MalformedKind::WebpChunk,
         ] {
             let _ = format!("{k:?}");
         }

--- a/src/exif.rs
+++ b/src/exif.rs
@@ -399,6 +399,10 @@ pub(crate) fn extract_exif_with_mime(
             // parse_exif_iter; this arm is unreachable in v3.3.
             unreachable!("PNG should have been dispatched at parse_exif_iter top");
         }
+        MediaMimeImage::Webp => {
+            // Wired to the real walker in the next task.
+            unreachable!("WebP dispatch not yet wired");
+        }
     };
     Ok((exif_data, state))
 }

--- a/src/exif.rs
+++ b/src/exif.rs
@@ -250,6 +250,7 @@ fn extract_exif_range(
         ParsingState::HeifExifSize(_) => None,
         ParsingState::Cr3ExifSize(_) => None,
         ParsingState::PngPastSignature => None,
+        ParsingState::WebpPastHeader(_) => None,
     });
     Ok(exif_data
         .and_then(|x| buf.subslice_in_range(x))

--- a/src/exif.rs
+++ b/src/exif.rs
@@ -399,10 +399,7 @@ pub(crate) fn extract_exif_with_mime(
             // parse_exif_iter; this arm is unreachable in v3.3.
             unreachable!("PNG should have been dispatched at parse_exif_iter top");
         }
-        MediaMimeImage::Webp => {
-            // Wired to the real walker in the next task.
-            unreachable!("WebP dispatch not yet wired");
-        }
+        MediaMimeImage::Webp => crate::webp::extract_exif(state, buf)?,
     };
     Ok((exif_data, state))
 }

--- a/src/file.rs
+++ b/src/file.rs
@@ -66,6 +66,7 @@ pub(crate) enum MediaMimeImage {
     Raf,
     Cr3,
     Png,
+    Webp,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Copy)]
@@ -92,6 +93,8 @@ impl TryFrom<&[u8]> for MediaMime {
             MediaMime::Image(MediaMimeImage::Tiff)
         } else if check_png(input).is_ok() {
             MediaMime::Image(MediaMimeImage::Png)
+        } else if check_webp(input).is_ok() {
+            MediaMime::Image(MediaMimeImage::Webp)
         } else if check_jpeg(input).is_ok() {
             MediaMime::Image(MediaMimeImage::Jpeg)
         } else if RafInfo::check(input).is_ok() {
@@ -238,6 +241,15 @@ fn check_png(input: &[u8]) -> Result<(), ()> {
     }
 }
 
+fn check_webp(input: &[u8]) -> Result<(), ()> {
+    // RIFF container tagged WEBP: "RIFF"(4) + fileSize(4) + "WEBP"(4).
+    if input.len() >= 12 && &input[0..4] == b"RIFF" && &input[8..12] == b"WEBP" {
+        Ok(())
+    } else {
+        Err(())
+    }
+}
+
 fn get_ftyp_and_major_brand(input: &[u8]) -> crate::Result<(BoxHolder<'_>, Option<&[u8]>)> {
     let (_, bbox) = BoxHolder::parse(input).map_err(|e| crate::Error::Malformed {
         kind: MalformedKind::IsoBmffBox,
@@ -334,6 +346,31 @@ mod v3_tests {
             res,
             Ok(MediaMime::Track(MediaMimeTrack::QuickTime))
         ));
+    }
+
+    #[test]
+    fn webp_riff_header_detected_as_image() {
+        // Minimal RIFF/WEBP header + one chunk header's worth of bytes.
+        let mut buf = Vec::new();
+        buf.extend_from_slice(b"RIFF");
+        buf.extend_from_slice(&16u32.to_le_bytes()); // riff size (value irrelevant to detection)
+        buf.extend_from_slice(b"WEBP");
+        buf.extend_from_slice(b"VP8X");
+        buf.extend_from_slice(&[0u8; 4]);
+        let res: Result<MediaMime, Error> = buf.as_slice().try_into();
+        assert!(matches!(res, Ok(MediaMime::Image(MediaMimeImage::Webp))));
+    }
+
+    #[test]
+    fn riff_without_webp_fourcc_is_not_webp() {
+        // A RIFF/WAVE header must NOT be misdetected as WebP.
+        let mut buf = Vec::new();
+        buf.extend_from_slice(b"RIFF");
+        buf.extend_from_slice(&16u32.to_le_bytes());
+        buf.extend_from_slice(b"WAVE");
+        buf.extend_from_slice(&[0u8; 8]);
+        let res: Result<MediaMime, Error> = buf.as_slice().try_into();
+        assert!(matches!(res, Err(Error::UnsupportedFormat)));
     }
 
     /// Minimal legacy QuickTime header: a single box header declaring

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -368,6 +368,7 @@ mod slice;
 mod utils;
 mod values;
 mod video;
+mod webp;
 
 #[cfg(test)]
 mod testkit;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -507,6 +507,11 @@ pub(crate) enum ParsingState {
     /// Carried across `Need` / `ClearAndSkip` retries so the resumed
     /// call doesn't re-check signature against a mid-stream slice.
     PngPastSignature,
+    /// WebP RIFF walker has validated the 12-byte header and skipped some
+    /// chunks. Carries the number of chunk-stream bytes still remaining
+    /// (from the resumed buffer's start) so the walker can stop cleanly at
+    /// the end of the RIFF chunk region — WebP has no terminator chunk.
+    WebpPastHeader(usize),
 }
 
 impl Display for ParsingState {
@@ -516,6 +521,9 @@ impl Display for ParsingState {
             ParsingState::HeifExifSize(n) => Display::fmt(&format!("ParsingState: {n}"), f),
             ParsingState::Cr3ExifSize(n) => Display::fmt(&format!("ParsingState: {n}"), f),
             ParsingState::PngPastSignature => f.write_str("ParsingState: PngPastSignature"),
+            ParsingState::WebpPastHeader(n) => {
+                Display::fmt(&format!("ParsingState: WebpPastHeader({n})"), f)
+            }
         }
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -811,7 +811,9 @@ impl MediaParser {
                 // keep the strict-EOF contract.
                 let is_png = matches!(
                     ms.mime,
-                    crate::file::MediaMime::Image(crate::file::MediaMimeImage::Png)
+                    crate::file::MediaMime::Image(
+                        crate::file::MediaMimeImage::Png | crate::file::MediaMimeImage::Webp
+                    )
                 );
                 match self.fill_buf(&mut ms.reader, INIT_BUF_SIZE) {
                     Ok(_) => {}
@@ -980,7 +982,10 @@ impl MediaParser {
                 // fill_buf returns UnexpectedEof. The bytes we need are
                 // already in the parse buffer — proceed. Other formats keep
                 // the strict-EOF contract.
-                let is_png = mime_img == crate::file::MediaMimeImage::Png;
+                let is_png = matches!(
+                    mime_img,
+                    crate::file::MediaMimeImage::Png | crate::file::MediaMimeImage::Webp
+                );
                 match self.fill_buf(&mut ms.reader, INIT_BUF_SIZE) {
                     Ok(_) => {}
                     Err(e)
@@ -1101,7 +1106,9 @@ mod tokio_impl {
                     // buffer; proceed.
                     let is_png = matches!(
                         ms.mime,
-                        crate::file::MediaMime::Image(crate::file::MediaMimeImage::Png)
+                        crate::file::MediaMime::Image(
+                            crate::file::MediaMimeImage::Png | crate::file::MediaMimeImage::Webp
+                        )
                     );
                     match <Self as AsyncBufParser>::fill_buf(self, &mut ms.reader, INIT_BUF_SIZE)
                         .await
@@ -1151,7 +1158,10 @@ mod tokio_impl {
                     // consumed during mime detection, so fill_buf returns
                     // UnexpectedEof; the bytes we need are already in the
                     // parse buffer.
-                    let is_png = mime_img == crate::file::MediaMimeImage::Png;
+                    let is_png = matches!(
+                        mime_img,
+                        crate::file::MediaMimeImage::Png | crate::file::MediaMimeImage::Webp
+                    );
                     match <Self as AsyncBufParser>::fill_buf(self, &mut ms.reader, INIT_BUF_SIZE)
                         .await
                     {
@@ -2217,5 +2227,101 @@ mod tests {
         let img = parser.parse_image_metadata_async(ms).await.unwrap();
         assert!(img.exif.is_none());
         assert!(img.format.is_some());
+    }
+
+    // --- WebP synthetic-buffer helpers (mirror src/webp.rs test builders) ---
+    #[cfg(test)]
+    fn webp_minimal_tiff_le() -> Vec<u8> {
+        // II + 0x002A + IFD0 offset 8 + IFD0 with one tag (Make="A") + next=0.
+        let mut t = Vec::new();
+        t.extend_from_slice(b"II");
+        t.extend_from_slice(&[0x2a, 0x00]);
+        t.extend_from_slice(&[0x08, 0, 0, 0]); // IFD0 at offset 8
+        t.extend_from_slice(&[0x01, 0x00]); // 1 entry
+                                            // Tag 0x010F (Make), type 2 (ASCII), count 2, inline value "A\0".
+        t.extend_from_slice(&[0x0f, 0x01]); // tag 0x010F
+        t.extend_from_slice(&[0x02, 0x00]); // type ASCII
+        t.extend_from_slice(&[0x02, 0x00, 0x00, 0x00]); // count 2
+        t.extend_from_slice(b"A\0\0\0"); // value "A\0" padded to 4 bytes
+        t.extend_from_slice(&[0, 0, 0, 0]); // next IFD = 0
+        t
+    }
+
+    #[cfg(test)]
+    fn webp_with_exif(tiff: &[u8]) -> Vec<u8> {
+        let mut exif_chunk = Vec::new();
+        exif_chunk.extend_from_slice(b"EXIF");
+        exif_chunk.extend_from_slice(&(tiff.len() as u32).to_le_bytes());
+        exif_chunk.extend_from_slice(tiff);
+        if tiff.len() % 2 == 1 {
+            exif_chunk.push(0);
+        }
+        let mut vp8x = Vec::new();
+        vp8x.extend_from_slice(b"VP8X");
+        vp8x.extend_from_slice(&10u32.to_le_bytes());
+        vp8x.extend_from_slice(&[0u8; 10]);
+
+        let mut body = Vec::new();
+        body.extend_from_slice(b"WEBP");
+        body.extend_from_slice(&vp8x);
+        body.extend_from_slice(&exif_chunk);
+
+        let mut out = Vec::new();
+        out.extend_from_slice(b"RIFF");
+        out.extend_from_slice(&(body.len() as u32).to_le_bytes());
+        out.extend_from_slice(&body);
+        out
+    }
+
+    #[test]
+    fn parse_exif_webp_from_memory() {
+        let tiff = webp_minimal_tiff_le();
+        let buf = webp_with_exif(&tiff);
+        let mut parser = MediaParser::new();
+        let ms = MediaSource::from_memory(buf).unwrap();
+        let iter = parser.parse_exif(ms).unwrap();
+        let exif: crate::Exif = iter.into();
+        assert_eq!(
+            exif.get(crate::ExifTag::Make).and_then(|v| v.as_str()),
+            Some("A")
+        );
+    }
+
+    #[test]
+    fn parse_exif_webp_no_exif_returns_not_found() {
+        // RIFF/WEBP with only a VP8X chunk (no EXIF).
+        let mut vp8x = Vec::new();
+        vp8x.extend_from_slice(b"VP8X");
+        vp8x.extend_from_slice(&10u32.to_le_bytes());
+        vp8x.extend_from_slice(&[0u8; 10]);
+        let mut body = Vec::new();
+        body.extend_from_slice(b"WEBP");
+        body.extend_from_slice(&vp8x);
+        let mut buf = Vec::new();
+        buf.extend_from_slice(b"RIFF");
+        buf.extend_from_slice(&(body.len() as u32).to_le_bytes());
+        buf.extend_from_slice(&body);
+
+        let mut parser = MediaParser::new();
+        let ms = MediaSource::from_memory(buf).unwrap();
+        let res = parser.parse_exif(ms);
+        assert!(matches!(res, Err(crate::Error::ExifNotFound)));
+    }
+
+    #[test]
+    fn parse_exif_webp_streaming_small_file() {
+        // Exercises the Png|Webp small-file EOF tolerance on the streaming
+        // path: a sub-INIT_BUF_SIZE WebP fully consumed during MIME prefill.
+        use std::io::Cursor;
+        let tiff = webp_minimal_tiff_le();
+        let buf = webp_with_exif(&tiff);
+        let mut parser = MediaParser::new();
+        let ms = MediaSource::seekable(Cursor::new(buf)).unwrap();
+        let iter = parser.parse_exif(ms).unwrap();
+        let exif: crate::Exif = iter.into();
+        assert_eq!(
+            exif.get(crate::ExifTag::Make).and_then(|v| v.as_str()),
+            Some("A")
+        );
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2324,4 +2324,20 @@ mod tests {
             Some("A")
         );
     }
+
+    #[cfg(feature = "tokio")]
+    #[tokio::test]
+    async fn parse_exif_webp_async_from_memory() {
+        use crate::AsyncMediaSource;
+        let tiff = webp_minimal_tiff_le();
+        let buf = webp_with_exif(&tiff);
+        let mut parser = MediaParser::new();
+        let ms = AsyncMediaSource::from_memory(buf).unwrap();
+        let iter = parser.parse_exif_async(ms).await.unwrap();
+        let exif: crate::Exif = iter.into();
+        assert_eq!(
+            exif.get(crate::ExifTag::Make).and_then(|v| v.as_str()),
+            Some("A")
+        );
+    }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2230,7 +2230,6 @@ mod tests {
     }
 
     // --- WebP synthetic-buffer helpers (mirror src/webp.rs test builders) ---
-    #[cfg(test)]
     fn webp_minimal_tiff_le() -> Vec<u8> {
         // II + 0x002A + IFD0 offset 8 + IFD0 with one tag (Make="A") + next=0.
         let mut t = Vec::new();
@@ -2247,7 +2246,6 @@ mod tests {
         t
     }
 
-    #[cfg(test)]
     fn webp_with_exif(tiff: &[u8]) -> Vec<u8> {
         let mut exif_chunk = Vec::new();
         exif_chunk.extend_from_slice(b"EXIF");

--- a/src/webp.rs
+++ b/src/webp.rs
@@ -30,6 +30,10 @@ pub(crate) fn extract_exif(
     state: Option<ParsingState>,
     buf: &[u8],
 ) -> Result<(Option<&[u8]>, Option<ParsingState>), ParsingErrorState> {
+    // True only when resuming after a ClearAndSkip (buf[0] is a chunk
+    // boundary). Captured before `state` is consumed by the match below.
+    let past_header = matches!(state, Some(ParsingState::WebpPastHeader(_)));
+
     // (cursor start, chunk-region bytes remaining from cursor)
     let (mut cursor, mut stream_left) = match state {
         Some(ParsingState::WebpPastHeader(left)) => (0usize, left),
@@ -57,7 +61,11 @@ pub(crate) fn extract_exif(
     };
 
     // Preserve the resume bound across `Need` returns (buffer only grows).
-    let preserve = |left: usize| Some(ParsingState::WebpPastHeader(left));
+    // Only meaningful once past the header: in the initial header path a
+    // `Need` must return `None` so the resumed call re-validates the 12-byte
+    // RIFF header still sitting at buf[0] (mirrors png.rs). Returning
+    // `WebpPastHeader` there would reset the cursor to 0 and misread "RIFF".
+    let preserve = |left: usize| past_header.then_some(ParsingState::WebpPastHeader(left));
 
     loop {
         // No room in the declared chunk region for another chunk header → done.
@@ -95,6 +103,13 @@ pub(crate) fn extract_exif(
             }
         };
 
+        // Chunk claims more than the RIFF container allows — stop at the
+        // container boundary. Placed before the EXIF branch so we never
+        // return bytes from outside the declared RIFF region.
+        if total > stream_left {
+            return Ok((None, Some(ParsingState::WebpPastHeader(0))));
+        }
+
         if fourcc == b"EXIF" {
             if total > in_buf {
                 return Err(ParsingErrorState::new(
@@ -109,13 +124,12 @@ pub(crate) fn extract_exif(
             if payload.starts_with(b"Exif\0\0") {
                 payload = &payload[6..];
             }
+            // A chunk containing only the stray marker (no TIFF body) is not
+            // usable EXIF — report it as absent rather than an empty slice.
+            if payload.is_empty() {
+                return Ok((None, preserve(stream_left)));
+            }
             return Ok((Some(payload), preserve(stream_left)));
-        }
-
-        // Chunk claims more than the RIFF container allows — treat as the end
-        // of useful data rather than skipping past EOF.
-        if total > stream_left {
-            return Ok((None, Some(ParsingState::WebpPastHeader(0))));
         }
 
         // Non-EXIF chunk. If it isn't fully buffered, skip it whole: advance
@@ -276,5 +290,47 @@ mod tests {
         // Any of Ok(None)/Need/ClearAndSkip/Failed is fine; the contract is
         // "no panic, no wrap-around, no infinite loop".
         let _ = extract_exif(None, &buf);
+    }
+
+    #[test]
+    fn header_only_need_then_resume_finds_exif() {
+        // First call sees only the 12-byte RIFF header (streaming I/O). It must
+        // return Need with state None (NOT WebpPastHeader) so the resumed call
+        // re-validates the header at buf[0] instead of misreading "RIFF" as a
+        // chunk header. This is the regression test for the Critical fix.
+        let tiff = minimal_tiff_le();
+        let full = webp(&[chunk(b"EXIF", &tiff)]);
+        let header_only = &full[..WEBP_HEADER_LEN];
+        let err = extract_exif(None, header_only).unwrap_err();
+        assert!(matches!(err.err, ParsingError::Need(_)));
+        assert!(
+            err.state.is_none(),
+            "initial-path Need must not carry WebpPastHeader"
+        );
+        let (exif, _) = extract_exif(err.state, &full).unwrap();
+        assert_eq!(exif.unwrap(), tiff.as_slice());
+    }
+
+    #[test]
+    fn non_exif_chunk_exceeding_riff_bound_returns_none() {
+        // RIFF declares a 12-byte chunk region but a chunk claims 1000 bytes.
+        // The walker must stop at the container boundary → Ok(None).
+        let mut buf = Vec::new();
+        buf.extend_from_slice(b"RIFF");
+        buf.extend_from_slice(&16u32.to_le_bytes()); // chunk region = 16 - 4 = 12
+        buf.extend_from_slice(b"WEBP");
+        buf.extend_from_slice(b"VP8L");
+        buf.extend_from_slice(&1000u32.to_le_bytes());
+        let (exif, _) = extract_exif(None, &buf).unwrap();
+        assert!(exif.is_none());
+    }
+
+    #[test]
+    fn exif_chunk_only_prefix_returns_none() {
+        // An EXIF chunk containing just the stray "Exif\0\0" marker and no
+        // TIFF body must not yield an empty EXIF slice.
+        let buf = webp(&[chunk(b"EXIF", b"Exif\0\0")]);
+        let (exif, _) = extract_exif(None, &buf).unwrap();
+        assert!(exif.is_none());
     }
 }

--- a/src/webp.rs
+++ b/src/webp.rs
@@ -1,0 +1,280 @@
+//! WebP (RIFF) chunk parser — pure-function EXIF extractor.
+//!
+//! WebP is a RIFF container: `"RIFF"` + fileSize(LE u32) + `"WEBP"`, then a
+//! sequence of chunks (`FourCC` + size(LE u32) + payload + one pad byte when
+//! size is odd). EXIF lives in an `EXIF` chunk (raw TIFF), present only in
+//! extended (VP8X) files, and sits *after* the image bitstream — so the
+//! walker must skip potentially-large `VP8 `/`VP8L`/`ANMF` chunks to reach it.
+//!
+//! Unlike PNG there is no terminator chunk, so the walk is bounded by the
+//! RIFF size field. That bound (bytes left in the chunk region) is threaded
+//! across a `ClearAndSkip` via [`ParsingState::WebpPastHeader`] so the walker
+//! stops cleanly (`Ok(None)` → `ExifNotFound`) instead of reading to EOF.
+//!
+//! Stateless and pure: operates on a `&[u8]` buffer plus the resume-state
+//! from any prior call. The caller (`MediaParser`) drives all I/O.
+
+use crate::error::{MalformedKind, ParsingError, ParsingErrorState};
+use crate::parser::ParsingState;
+
+const WEBP_HEADER_LEN: usize = 12; // "RIFF" + size(4) + "WEBP"
+const CHUNK_HEADER_LEN: usize = 8; // FourCC(4) + size(4)
+
+/// Walk the RIFF chunk stream and return the `EXIF` chunk payload (raw TIFF),
+/// borrowed from `buf`, if present.
+///
+/// `state` is `Some(WebpPastHeader(stream_left))` only after a `ClearAndSkip`:
+/// `buf[0]` is then a chunk boundary rather than the 12-byte file header, and
+/// `stream_left` is the number of chunk-region bytes remaining from `buf[0]`.
+pub(crate) fn extract_exif(
+    state: Option<ParsingState>,
+    buf: &[u8],
+) -> Result<(Option<&[u8]>, Option<ParsingState>), ParsingErrorState> {
+    // (cursor start, chunk-region bytes remaining from cursor)
+    let (mut cursor, mut stream_left) = match state {
+        Some(ParsingState::WebpPastHeader(left)) => (0usize, left),
+        _ => {
+            if buf.len() < WEBP_HEADER_LEN {
+                return Err(ParsingErrorState::new(
+                    ParsingError::Need(WEBP_HEADER_LEN - buf.len()),
+                    None,
+                ));
+            }
+            if &buf[0..4] != b"RIFF" || &buf[8..12] != b"WEBP" {
+                return Err(ParsingErrorState::new(
+                    ParsingError::Failed {
+                        kind: MalformedKind::WebpChunk,
+                        message: "WebP: bad RIFF/WEBP header".into(),
+                    },
+                    None,
+                ));
+            }
+            // RIFF size = whole file minus 8 ("RIFF" + size field). The chunk
+            // region is everything after the "WEBP" FourCC, i.e. riff_size - 4.
+            let riff_size = u32::from_le_bytes([buf[4], buf[5], buf[6], buf[7]]) as usize;
+            (WEBP_HEADER_LEN, riff_size.saturating_sub(4))
+        }
+    };
+
+    // Preserve the resume bound across `Need` returns (buffer only grows).
+    let preserve = |left: usize| Some(ParsingState::WebpPastHeader(left));
+
+    loop {
+        // No room in the declared chunk region for another chunk header → done.
+        if stream_left < CHUNK_HEADER_LEN {
+            return Ok((None, Some(ParsingState::WebpPastHeader(stream_left))));
+        }
+        // Buffer doesn't yet hold the next chunk header — ask for more bytes.
+        let in_buf = buf.len() - cursor;
+        if in_buf < CHUNK_HEADER_LEN {
+            return Err(ParsingErrorState::new(
+                ParsingError::Need(CHUNK_HEADER_LEN - in_buf),
+                preserve(stream_left),
+            ));
+        }
+
+        let fourcc = &buf[cursor..cursor + 4];
+        let size = u32::from_le_bytes([
+            buf[cursor + 4],
+            buf[cursor + 5],
+            buf[cursor + 6],
+            buf[cursor + 7],
+        ]);
+        // total = header(8) + payload(size) + pad(1 if size is odd).
+        let pad = (size & 1) as usize;
+        let total = match (size as usize).checked_add(CHUNK_HEADER_LEN + pad) {
+            Some(t) => t,
+            None => {
+                return Err(ParsingErrorState::new(
+                    ParsingError::Failed {
+                        kind: MalformedKind::WebpChunk,
+                        message: "WebP: chunk size overflows addressable size".into(),
+                    },
+                    preserve(stream_left),
+                ));
+            }
+        };
+
+        if fourcc == b"EXIF" {
+            if total > in_buf {
+                return Err(ParsingErrorState::new(
+                    ParsingError::Need(total - in_buf),
+                    preserve(stream_left),
+                ));
+            }
+            let data_start = cursor + CHUNK_HEADER_LEN;
+            let data_end = data_start + size as usize;
+            let mut payload = &buf[data_start..data_end];
+            // Some encoders wrongly prepend the JPEG APP1 "Exif\0\0" marker.
+            if payload.starts_with(b"Exif\0\0") {
+                payload = &payload[6..];
+            }
+            return Ok((Some(payload), preserve(stream_left)));
+        }
+
+        // Chunk claims more than the RIFF container allows — treat as the end
+        // of useful data rather than skipping past EOF.
+        if total > stream_left {
+            return Ok((None, Some(ParsingState::WebpPastHeader(0))));
+        }
+
+        // Non-EXIF chunk. If it isn't fully buffered, skip it whole: advance
+        // the parser by `cursor + total` (bytes walked in `buf` plus this
+        // chunk) and resume past the header with the reduced bound.
+        if total > in_buf {
+            return Err(ParsingErrorState::new(
+                ParsingError::ClearAndSkip(cursor + total),
+                Some(ParsingState::WebpPastHeader(stream_left - total)),
+            ));
+        }
+        cursor += total;
+        stream_left -= total;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Minimal little-endian TIFF: II + 0x002A + IFD0 offset 8 + empty IFD0.
+    fn minimal_tiff_le() -> Vec<u8> {
+        let mut t = Vec::new();
+        t.extend_from_slice(b"II");
+        t.extend_from_slice(&[0x2a, 0x00]);
+        t.extend_from_slice(&[0x08, 0, 0, 0]);
+        t.extend_from_slice(&[0, 0]);
+        t.extend_from_slice(&[0, 0, 0, 0]);
+        t
+    }
+
+    fn chunk(fourcc: &[u8; 4], data: &[u8]) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend_from_slice(fourcc);
+        out.extend_from_slice(&(data.len() as u32).to_le_bytes());
+        out.extend_from_slice(data);
+        if data.len() % 2 == 1 {
+            out.push(0); // pad to even
+        }
+        out
+    }
+
+    /// Wrap chunk bytes in a RIFF/WEBP container with a correct size field.
+    fn webp(chunks: &[Vec<u8>]) -> Vec<u8> {
+        let mut body = Vec::new();
+        body.extend_from_slice(b"WEBP");
+        for c in chunks {
+            body.extend_from_slice(c);
+        }
+        let mut out = Vec::new();
+        out.extend_from_slice(b"RIFF");
+        out.extend_from_slice(&(body.len() as u32).to_le_bytes());
+        out.extend_from_slice(&body);
+        out
+    }
+
+    #[test]
+    fn no_exif_returns_none() {
+        let buf = webp(&[chunk(b"VP8X", &[0u8; 10])]);
+        let (exif, _) = extract_exif(None, &buf).unwrap();
+        assert!(exif.is_none());
+    }
+
+    #[test]
+    fn extracts_exif_payload() {
+        let tiff = minimal_tiff_le();
+        let buf = webp(&[chunk(b"VP8X", &[0u8; 10]), chunk(b"EXIF", &tiff)]);
+        let (exif, _) = extract_exif(None, &buf).unwrap();
+        assert_eq!(exif.unwrap(), tiff.as_slice());
+    }
+
+    #[test]
+    fn strips_exif_prefix() {
+        let tiff = minimal_tiff_le();
+        let mut payload = Vec::new();
+        payload.extend_from_slice(b"Exif\0\0");
+        payload.extend_from_slice(&tiff);
+        let buf = webp(&[chunk(b"EXIF", &payload)]);
+        let (exif, _) = extract_exif(None, &buf).unwrap();
+        assert_eq!(exif.unwrap(), tiff.as_slice());
+    }
+
+    #[test]
+    fn odd_length_chunk_padding_accounted() {
+        // A 3-byte chunk (odd → 1 pad byte) before EXIF. If padding is
+        // miscounted, the EXIF FourCC won't align and extraction fails.
+        let tiff = minimal_tiff_le();
+        let buf = webp(&[chunk(b"ICCP", &[1, 2, 3]), chunk(b"EXIF", &tiff)]);
+        let (exif, _) = extract_exif(None, &buf).unwrap();
+        assert_eq!(exif.unwrap(), tiff.as_slice());
+    }
+
+    #[test]
+    fn bad_header_fails() {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(b"RIFF");
+        buf.extend_from_slice(&16u32.to_le_bytes());
+        buf.extend_from_slice(b"WAVE"); // not WEBP
+        buf.extend_from_slice(&[0u8; 8]);
+        let err = extract_exif(None, &buf).unwrap_err();
+        assert!(matches!(
+            err.err,
+            ParsingError::Failed {
+                kind: MalformedKind::WebpChunk,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn truncated_header_needs_more() {
+        let buf = b"RIFF\x00\x00".to_vec();
+        let err = extract_exif(None, &buf).unwrap_err();
+        assert!(matches!(err.err, ParsingError::Need(_)));
+    }
+
+    #[test]
+    fn large_leading_chunk_clear_and_skips() {
+        // A VP8L chunk declaring 50_000 bytes not present in the buffer must
+        // yield ClearAndSkip(cursor + total) + WebpPastHeader(remaining).
+        let mut buf = Vec::new();
+        buf.extend_from_slice(b"RIFF");
+        // riff_size large enough to contain the declared chunk + an EXIF later.
+        buf.extend_from_slice(&1_000_000u32.to_le_bytes());
+        buf.extend_from_slice(b"WEBP");
+        // VP8L header only, claiming 50_000 bytes of body.
+        buf.extend_from_slice(b"VP8L");
+        buf.extend_from_slice(&50_000u32.to_le_bytes());
+        let err = extract_exif(None, &buf).unwrap_err();
+        match err.err {
+            // cursor at skip time = 12 (header); total = 8 + 50_000 (+0 pad).
+            ParsingError::ClearAndSkip(n) => assert_eq!(n, 12 + 8 + 50_000),
+            other => panic!("expected ClearAndSkip, got {other:?}"),
+        }
+        assert!(matches!(err.state, Some(ParsingState::WebpPastHeader(_))));
+    }
+
+    #[test]
+    fn resumes_past_header_finds_exif() {
+        // Simulate the post-ClearAndSkip resume: buf starts at a chunk
+        // boundary (no RIFF header), state carries the remaining bound.
+        let tiff = minimal_tiff_le();
+        let exif_chunk = chunk(b"EXIF", &tiff);
+        let stream_left = exif_chunk.len();
+        let (exif, _) =
+            extract_exif(Some(ParsingState::WebpPastHeader(stream_left)), &exif_chunk).unwrap();
+        assert_eq!(exif.unwrap(), tiff.as_slice());
+    }
+
+    #[test]
+    fn size_max_does_not_panic() {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(b"RIFF");
+        buf.extend_from_slice(&u32::MAX.to_le_bytes());
+        buf.extend_from_slice(b"WEBP");
+        buf.extend_from_slice(b"VP8L");
+        buf.extend_from_slice(&u32::MAX.to_le_bytes());
+        // Any of Ok(None)/Need/ClearAndSkip/Failed is fine; the contract is
+        // "no panic, no wrap-around, no infinite loop".
+        let _ = extract_exif(None, &buf);
+    }
+}


### PR DESCRIPTION
## Summary

Adds WebP image support to `nom-exif`: detects RIFF/WEBP files and extracts EXIF/GPS from the `EXIF` chunk via the unified `parse_exif` / `read_exif` (sync + async) APIs. Scope is EXIF-only (no XMP).

- **MIME detection** (`src/file.rs`): new `MediaMimeImage::Webp` + `check_webp` (`"RIFF"…"WEBP"`), wired into the detection chain.
- **Pure RIFF chunk walker** (`src/webp.rs`): `webp::extract_exif(state, buf)` walks the chunk stream, skipping large image-bitstream chunks via `ClearAndSkip`, returning the `EXIF` payload (raw TIFF). Bounds the walk by the RIFF size field (WebP has no terminator chunk) and threads the remaining-bytes bound across skips via `ParsingState::WebpPastHeader(usize)`. Strips a stray `Exif\0\0` marker if an encoder wrote one.
- **Generic dispatch integration** (`src/exif.rs`): rides the existing `extract_exif_with_mime` path — reuses the sync **and** async drivers with zero async-specific code. New `MalformedKind::WebpChunk`.
- **Streaming EOF tolerance** (`src/parser.rs`): small-file tolerance widened from `Png` to `Png | Webp`.

## Design notes

WebP EXIF sits *after* the image bitstream, so the walker must skip potentially-large `VP8 `/`VP8L`/`ANMF` chunks to reach it — handled by `ClearAndSkip` with the RIFF-size bound carried across the skip. A no-EXIF WebP terminates cleanly with `Error::ExifNotFound` rather than reading to EOF.

Full design + implementation plan under `docs/superpowers/`.

## Test Plan

- [x] `cargo test` — 427 passed, 0 failed (default features)
- [x] `cargo test --features tokio` — 432 passed, 0 failed
- [x] `cargo fmt --check` clean; `cargo clippy --all-targets --all-features` no issues
- [x] 18 WebP-specific tests: 12 walker unit tests (Need/ClearAndSkip resume, prefix strip, odd-size padding, RIFF-bound, overflow, bad/truncated header), 2 MIME-detection tests (incl. RIFF/WAVE negative), 4 end-to-end (memory sync, streaming sub-buffer, no-EXIF → ExifNotFound, async)