### PR TITLE
fix: avoid overflow panic on malformed iloc extent offsets

### DIFF
--- a/src/bbox/iloc.rs
+++ b/src/bbox/iloc.rs
@@ -118,11 +118,8 @@ impl IlocBox {
     pub fn item_offset_len(&self, id: u32) -> Option<(ConstructionMethod, u64, u64)> {
         self.items.get(&id).and_then(|item| {
             let extent = item.extents.first()?;
-            Some((
-                item.construction_method,
-                item.base_offset + extent.offset,
-                extent.length,
-            ))
+            let offset = item.base_offset.checked_add(extent.offset)?;
+            Some((item.construction_method, offset, extent.length))
         })
     }
 }

--- a/src/bbox/meta.rs
+++ b/src/bbox/meta.rs
@@ -113,8 +113,8 @@ impl MetaBox {
                     .and_then(|iloc| iloc.item_offset_len(exif_infe.id))
             })
             .and_then(|(construction_method, offset, length)| {
-                let start = offset as usize;
-                let end = (offset + length) as usize;
+                let start = usize::try_from(offset).ok()?;
+                let end = usize::try_from(offset.checked_add(length)?).ok()?;
                 match construction_method {
                     ConstructionMethod::FileOffset => Some(start..end),
                     ConstructionMethod::IdatOffset => {
@@ -136,6 +136,18 @@ mod tests {
 
     use super::*;
     use test_case::test_case;
+
+    #[test]
+    fn exif_data_offset_overflowing_iloc() {
+        let hex = "000000556d657461000000000000002369696e6600000000000100000015696e66650200000000010000457869660000000026696c6f630000000088000001000100000001ffffffffffffffff0000000000000001";
+        let buf: Vec<u8> = (0..hex.len())
+            .step_by(2)
+            .map(|i| u8::from_str_radix(&hex[i..i + 2], 16).unwrap())
+            .collect();
+        let (remain, meta) = MetaBox::parse_box(&buf).unwrap();
+        assert_eq!(remain, b"");
+        assert_eq!(meta.exif_data_offset(), None);
+    }
 
     #[test_case("exif.heic", 2618)]
     fn meta(path: &str, meta_size: usize) {


### PR DESCRIPTION
A HEIC file whose iloc extent offset plus length exceeds u64::MAX makes read_exif panic (add-with-overflow in debug, out-of-range slice index in release) instead of returning an error. This switches the offset arithmetic in IlocBox::item_offset_len and MetaBox::exif_data_offset to checked operations so such files fail parsing normally, and adds a test with a meta box carrying an overflowing extent.

Fixes #63